### PR TITLE
fix: resolve React import error in frontend layout

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,8 +1,19 @@
 {
-  "extends": ["next/core-web-vitals"],
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "globals": {
+    "React": "readonly",
+    "JSX": "readonly"
+  },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "react/no-unescaped-entities": "error"
+    "react/no-unescaped-entities": "error",
+    "react/react-in-jsx-scope": "off",
+    "no-undef": "error"
   }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 
+import React from "react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Pacifico } from "next/font/google";
 import "./globals.css";


### PR DESCRIPTION
- Add explicit React import to app/layout.tsx to fix 'React is not defined' ESLint error
- Enhance .eslintrc.json with proper Next.js TypeScript configuration
- Add React and JSX globals for better ESLint understanding
- Include next/typescript in extends for comprehensive Next.js support
- Fix CI/CD frontend linting pipeline failure