### PR TITLE
fix: remove npm caching from CI workflows to resolve lockfile depende…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
 
     - name: Install dependencies
       run: |
@@ -65,7 +64,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
 
     - name: Install frontend dependencies
       working-directory: ./frontend
@@ -101,7 +99,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
 
     - name: Install dependencies
       run: |
@@ -142,7 +139,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
         registry-url: 'https://npm.pkg.github.com'
 
     - name: Install dependencies
@@ -173,7 +169,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
         cache: 'npm'
 
     - name: Download frontend build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
       
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,7 +49,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
     
     - name: Install dependencies
       working-directory: ./frontend
@@ -94,7 +93,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
     
     - name: Install dependencies
       working-directory: ./frontend
@@ -131,7 +129,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
     
     - name: Install dependencies
       working-directory: ./frontend
@@ -168,7 +165,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
     
     - name: Install dependencies
       working-directory: ./frontend

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
 
     - name: Install dependencies
       run: |
@@ -132,7 +131,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
…ncy errors

Since package-lock.json files are in .gitignore, removing cache: 'npm' from all setup-node actions to prevent 'Dependencies lock file is not found' errors in CI.